### PR TITLE
Change page title to the dat archive title and point albums to the dat site they were created from

### DIFF
--- a/album.html
+++ b/album.html
@@ -3,11 +3,11 @@
   <head>
     <title></title>
     <meta charset="utf-8"/>
-    <link rel="stylesheet" href="dat://f0abcd6b1c4fc524e2d48da043b3d8399b96d9374d6606fca51182ee230b6b59/css/base.css"/>
-    <link rel="stylesheet" href="dat://f0abcd6b1c4fc524e2d48da043b3d8399b96d9374d6606fca51182ee230b6b59/css/header.css"/>
-    <link rel="stylesheet" href="dat://f0abcd6b1c4fc524e2d48da043b3d8399b96d9374d6606fca51182ee230b6b59/css/buttons.css"/>
-    <link rel="stylesheet" href="dat://f0abcd6b1c4fc524e2d48da043b3d8399b96d9374d6606fca51182ee230b6b59/css/album.css"/>
-    <link rel="stylesheet" href="dat://f0abcd6b1c4fc524e2d48da043b3d8399b96d9374d6606fca51182ee230b6b59/css/prompt.css"/>
+    <link rel="stylesheet" href="{{DAT_ARCHIVE_URL}}/css/base.css"/>
+    <link rel="stylesheet" href="{{DAT_ARCHIVE_URL}}/css/header.css"/>
+    <link rel="stylesheet" href="{{DAT_ARCHIVE_URL}}/css/buttons.css"/>
+    <link rel="stylesheet" href="{{DAT_ARCHIVE_URL}}/css/album.css"/>
+    <link rel="stylesheet" href="{{DAT_ARCHIVE_URL}}/css/prompt.css"/>
   </head>
 
   <body>
@@ -17,7 +17,7 @@
     <!-- TODO put ellipsis in :after -->
 
     <header>
-      <a href="dat://f0abcd6b1c4fc524e2d48da043b3d8399b96d9374d6606fca51182ee230b6b59/">
+      <a href="{{DAT_ARCHIVE_URL}}/">
         &laquo All albums
       </a>
 
@@ -47,6 +47,6 @@
       <div class="album-images"></div>
     </div>
     <textarea id="url"></textarea>
-    <script src="dat://f0abcd6b1c4fc524e2d48da043b3d8399b96d9374d6606fca51182ee230b6b59/js/album.js"></script>
+    <script src="{{DAT_ARCHIVE_URL}}/js/album.js"></script>
   </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -19,6 +19,7 @@
   try {
     archive = new DatArchive(window.location)
     archiveInfo = await archive.getInfo()
+    document.title = archiveInfo.title
   } catch (err) {
     updatePrompt('<p>Something went wrong.</p><a href="https://github.com/taravancil/p2p-photo-gallery">Report an issue</a>')
   }

--- a/js/index.js
+++ b/js/index.js
@@ -49,7 +49,8 @@
 
     // write the album's assets
     const html = await archive.readFile('album.html')
-    await album.writeFile('index.html', html)
+    html2 = html.replace(/{{DAT_ARCHIVE_URL}}/g, archive.url)
+    await album.writeFile('index.html', html2)
     await album.commit()
 
     // go to the new archive


### PR DESCRIPTION
This pull request contains two changes which are open for discussion:

* The title of the album overview page is set to the title of the dat archive
* Point newly created albums to the dat page they were created from (required to avoid having to change the dat URLs manually, if the app is used from a fork)