### PR TITLE
Fix two bugs occuring during deleting images

### DIFF
--- a/js/album.js
+++ b/js/album.js
@@ -72,16 +72,18 @@
   }
 
   async function onDeleteSelected () {
-    for (let i = 0; i < selectedImages.length; i++) {
-      const path = selectedImages[i]
-
-      // remove from DOM
-      document.querySelector(`[src='${path}']`).parentNode.remove()
-
-      // remove from archive
-      await archive.unlink(selectedImages[i])
+    for (let path of selectedImages) {
+      const imgTag = document.querySelector(`[src='${path}']`)
+      if (imgTag) {
+        // remove from DOM
+        imgTag.parentNode.remove()
+        // remove from archive
+        await archive.unlink(path)
+      }
     }
     await archive.commit()
+    // clear selectedImages array
+    selectedImages.length = 0
   }
 
   function onEditInfo () {

--- a/js/album.js
+++ b/js/album.js
@@ -62,7 +62,8 @@
     e.target.parentNode.classList.toggle('selected')
 
     // full src is dat://{key}/{path}, so strip dat://{key}
-    const path = e.target.src.slice('dat://'.length + 64)
+    const datHashLength = 64
+    const path = e.target.src.slice('dat://'.length + datHashLength)
     const idx = selectedImages.indexOf(path)
 
     // either add or remove the path to selectedImages

--- a/js/album.js
+++ b/js/album.js
@@ -191,7 +191,7 @@
     el.classList.add('img-container')
 
     const img = document.createElement('img')
-    img.src = src
+    img.src = encodeURI(src)
     img.style.transform = IMAGE_ROTATION[orientation]
     img.addEventListener('click', onToggleSelected)
 


### PR DESCRIPTION
This PR fixes the following two bugs:
1. Clear the `selectedImages` array, after the images are deleted. Otherwise, the method tries to delete nonexisting images again and fails.
2. If a file is added to an album, which contains a space character in its name, it can not be deleted afterwards.

Details on item 2:

In the function `onToggleSelected`, the path is extracted from `e.target.src`, which is a dat URI.
If the file pointed to containes a space in the filename, it will be encoded as `%20` in the dat URI.
However, the filename passed to `appendImage()` and thus the `src` attribute of the created img tag does contain the space and not the `%20`.
Accordingly, the path added to `selectedImages` is different than the `src` attribute of the matching `img` tag, leading to `document.querySelector()` returning `null`.
Encoding the filename before setting it as `img.src` fixes this problem.